### PR TITLE
[CMake] don't overwrite __doc__ in python2

### DIFF
--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -33,14 +33,21 @@ FOREACH(IDL ${IDL_SOURCES})
     DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/gepetto/viewer/corba)
 
   # Python
-  GENERATE_IDL_PYTHON (gepetto/viewer/corba/${IDL}
-    ${CMAKE_SOURCE_DIR}/idl/gepetto/viewer
-    ARGUMENTS
-    -p${CMAKE_SOURCE_DIR}/cmake/hpp/idl
-    -bomniidl_be_python_with_docstring
+  SET(_IDL_PYTHON_ARGUMENTS
     -C${CMAKE_CURRENT_BINARY_DIR}
     -K
     -Wbpackage=gepetto.corbaserver
+    )
+  IF(PYTHON_VERSION_MAJOR EQUAL 3)
+    SET(_IDL_PYTHON_ARGUMENTS
+      -p${CMAKE_SOURCE_DIR}/cmake/hpp/idl
+      -bomniidl_be_python_with_docstring
+      ${_IDL_PYTHON_ARGUMENTS}
+      )
+  ENDIF(PYTHON_VERSION_MAJOR EQUAL 3)
+  GENERATE_IDL_PYTHON (gepetto/viewer/corba/${IDL}
+    ${CMAKE_SOURCE_DIR}/idl/gepetto/viewer
+    ARGUMENTS ${_IDL_PYTHON_ARGUMENTS}
     )
 
   STRING(REGEX REPLACE "-" "_" IDL_UNDERSCORE "${IDL}")

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -43,3 +43,5 @@ ENDMACRO(ADD_TESTCASE)
 
 ADD_TESTCASE (colormap FALSE)
 # ADD_TESTCASE (osgviewerQt FALSE)
+
+ADD_PYTHON_UNIT_TEST("py-trivial" "tests/trivial.py" "src")

--- a/tests/trivial.py
+++ b/tests/trivial.py
@@ -1,0 +1,2 @@
+import gepetto
+import gepetto.corbaserver


### PR DESCRIPTION
Hi,

This PR adds a trivial python test that imports `gepetto` & `gepetto.corbaserver`.
With Python 2.7 & omniORB 4.2 (available in Ubuntu 18.04), this test fails with:
```
AttributeError: attribute '__doc__' of 'type' objects is not writable
```
(https://gepgitlab.laas.fr/gsaurel/gepetto-viewer-corba/-/jobs/19868)

This issue, raised in #122, is then workaround by disabling the new feature that adds docstrings. And now this test pass: 
https://gepgitlab.laas.fr/gsaurel/gepetto-viewer-corba/pipelines/4437